### PR TITLE
Secondary Sort by Weight for V/W Default Sort

### DIFF
--- a/dist/Data/Interface/skyui/config.txt
+++ b/dist/Data/Interface/skyui/config.txt
@@ -360,7 +360,7 @@ columns.valueWeightColumn.state1.label.text = '$V/W'
 columns.valueWeightColumn.state1.label.arrowDown = true
 columns.valueWeightColumn.state1.entry.text = @infoValueWeight
 columns.valueWeightColumn.state1.sortAttributes = <infoValueWeight, infoWeight, text>
-columns.valueWeightColumn.state1.sortOptions = <{DESCENDING | NUMERIC}, DESCENDING | NUMERIC}, {ASCENDING | CASEINSENSITIVE}>
+columns.valueWeightColumn.state1.sortOptions = <{DESCENDING | NUMERIC}, {DESCENDING | NUMERIC}, {ASCENDING | CASEINSENSITIVE}>
 
 columns.valueWeightColumn.state2.label.text = '$V/W'
 columns.valueWeightColumn.state2.entry.text = @infoValueWeight

--- a/dist/Data/Interface/skyui/config.txt
+++ b/dist/Data/Interface/skyui/config.txt
@@ -359,13 +359,13 @@ columns.valueWeightColumn.hidden = true
 columns.valueWeightColumn.state1.label.text = '$V/W'
 columns.valueWeightColumn.state1.label.arrowDown = true
 columns.valueWeightColumn.state1.entry.text = @infoValueWeight
-columns.valueWeightColumn.state1.sortAttributes = <infoValueWeight, text>
-columns.valueWeightColumn.state1.sortOptions = <{DESCENDING | NUMERIC}, {ASCENDING | CASEINSENSITIVE}>
+columns.valueWeightColumn.state1.sortAttributes = <infoValueWeight, infoWeight, text>
+columns.valueWeightColumn.state1.sortOptions = <{DESCENDING | NUMERIC}, DESCENDING | NUMERIC}, {ASCENDING | CASEINSENSITIVE}>
 
 columns.valueWeightColumn.state2.label.text = '$V/W'
 columns.valueWeightColumn.state2.entry.text = @infoValueWeight
-columns.valueWeightColumn.state2.sortAttributes = <infoValueWeight, text>
-columns.valueWeightColumn.state2.sortOptions = <{ASCENDING | NUMERIC}, {ASCENDING | CASEINSENSITIVE}>
+columns.valueWeightColumn.state2.sortAttributes = <infoValueWeight, infoWeight, text>
+columns.valueWeightColumn.state2.sortOptions = <{ASCENDING | NUMERIC}, {ASCENDING | NUMERIC}, {ASCENDING | CASEINSENSITIVE}>
 
 
 ; MAGIC NAME COLUMN -------------------------------------------------------


### PR DESCRIPTION
Adding a secondary sort to the sort options for v/w such that it will
sort by weight (I was thinking it would be more convenient). I'm not
sure if this change is enough to achieve this as I am not sure how to
build Sky UI...
