### PR TITLE
Changed ProcessItem() two-handed search to right hand

### DIFF
--- a/dist/Data/Scripts/Source/SKI_FavoritesManager.psc
+++ b/dist/Data/Scripts/Source/SKI_FavoritesManager.psc
@@ -804,7 +804,8 @@ bool function ProcessItem(Form a_item, int a_itemType, bool a_allowDeferring = t
 
 		; It's two-handed and both hands are free
 		elseIf (weaponType > 4 && !_usedRightHand && !_usedLeftHand)
-			if (a_item == PlayerREF.GetEquippedObject(0) && a_itemId != PlayerREF.GetEquippedItemId(0))
+			; Changed this line from GetEquippedItemId(0) to GetEquippedItemId(1) since two-handed weapons don't seem to appear in left hand
+			if (a_item == PlayerREF.GetEquippedObject(0) && a_itemId != PlayerREF.GetEquippedItemId(1))
 				UnequipHand(0)
 			endIf
 			PlayerREF.EquipItemById(itemWeapon, a_itemId, equipSlot = 0, equipSound = _silenceEquipSounds)


### PR DESCRIPTION
PlayerREF.GetEquippedItemId(0) returns 0 when a two-handed weapon is equipped
PlayerREF.GetEquippedObject(0) seems to work OK.

e.g. Output from PrintGroupItems() 
[04/10/2021 - 08:33:50PM] PrintGroupItems called on group 1
[04/10/2021 - 08:33:50PM] 37 is -102131405, form is [Form < (020176F1)>]: Dragonbone Bow
[04/10/2021 - 08:33:50PM] Group icon is -102131405, form is [Form < (020176F1)>]: Dragonbone Bow

But output from 
Debug.Trace("PlayerREF.GetEquippedObject(0) is " + PlayerREF.GetEquippedObject(0) + ", PlayerREF.GetEquippedObject(1) is " + PlayerREF.GetEquippedObject(1))
Debug.Trace("PlayerREF.GetEquippedItemId(0) is " + PlayerREF.GetEquippedItemId(0) + ", PlayerREF.GetEquippedItemId(1) is " + PlayerREF.GetEquippedItemId(1))

is 
[04/10/2021 - 08:32:15PM] PlayerREF.GetEquippedObject(0) is [WEAPON < (000240D2)>], PlayerREF.GetEquippedObject(1) is [Form < (02014FCE)>]
[04/10/2021 - 08:32:15PM] PlayerREF.GetEquippedItemId(0) is 0, PlayerREF.GetEquippedItemId(1) is -102131405